### PR TITLE
Lima 3

### DIFF
--- a/lima/lima_args.py
+++ b/lima/lima_args.py
@@ -91,12 +91,12 @@ def parse_lima_args() -> Dict[str, Path]:
         arg_dict[ARG_DICT_KEY_DIR] = dir_path
     # word
     try:
-        words = _validate_path_arg(path_arg=parsed_args.words, arg_name='--words')
-        validate_path_file(words)
+        words_path = _validate_path_arg(path_arg=parsed_args.words, arg_name='--words')
+        validate_path_file(words_path)
     except AttributeError:
         pass  # Likely indicates a "partial refactor" BUG
     finally:
-        arg_dict[ARG_DICT_KEY_WORDS] = words
+        arg_dict[ARG_DICT_KEY_WORDS] = words_path
 
     # DONE
     return arg_dict

--- a/lima/lima_args.py
+++ b/lima/lima_args.py
@@ -7,11 +7,12 @@ import argparse
 import sys
 # Third Party Imports
 # Local Imports
-from lima.lima_validation import validate_path_file, validate_string
+from lima.lima_validation import validate_path_dir, validate_path_file, validate_string
 
 
 # ARGUMENT DICTIONARY KEYS
 ARG_DICT_KEY_FILE = 'file'    # -f, --file
+ARG_DICT_KEY_DIR = 'dir'      # -d, --dir
 ARG_DICT_KEY_WORDS = 'words'  # -w, --words
 
 
@@ -42,32 +43,56 @@ def parse_lima_args() -> Dict[str, Path]:
     """
     # LOCAL VARIABLES
     parsed_args = None  # Parsed args as an argparse.Namespace object
-    file_path = None    # Path object of the target file
-    words = None        # Path object to the dirty word list
+    file_path = None    # Path object of the file (Use Case 1)
+    dir_path = None     # Path object of the directory (Use Case 2)
+    words_path = None   # Path object to the dirty word list
     arg_dict = {}       # Return value containing arg values
     # Object for parsing command line input into Python objects
     parser = LimaParser(prog='LIVING MANUAL (LIMA)')
+    subs = None         # Subparsers
+    file_parser = None  # Use Case 1 (file) subparser
+    dir_parser = None   # Use Case 2 (directory) subparser
 
     # ARGUMENTS
     # Add
-    parser.add_argument('-f', '--file', action='store', required=True,
-                        help='Target file to search for dirty words')
-    parser.add_argument('-w', '--words', action='store', required=True,
+    subs = parser.add_subparsers(required=True)
+    # Use Case 1: File
+    file_parser = subs.add_parser('file', help='Search a file for dirty words')
+    file_parser.add_argument('-f', '--file', action='store', required=True,
+                             help='Target file to search for dirty words')
+    file_parser.add_argument('-w', '--words', action='store', required=True,
                         help='Dirty word list')
+    # Use Case 2: Directory
+    dir_parser = subs.add_parser('dir', help='Search a directory for files with dirty words')
+    dir_parser.add_argument('-d', '--dir', action='store', required=True,
+                            help='Search for dirty words in all files found in this directory')
+    dir_parser.add_argument('-w', '--words', action='store', required=True,
+                        help='Dirty word list')
+
     # Parse
     parsed_args = parser.parse_args()
 
     # Validate
     # file
     try:
-        file_path = _validate_path_arg(file_arg=parsed_args.file, arg_name='--file')
+        file_path = _validate_path_arg(path_arg=parsed_args.file, arg_name='--file')
+        validate_path_file(file_path)
     except AttributeError:
         pass  # Likely indicates a "partial refactor" BUG
     finally:
         arg_dict[ARG_DICT_KEY_FILE] = file_path
+    # dir
+    try:
+        dir_path = _validate_path_arg(path_arg=parsed_args.dir, arg_name='--dir')
+        validate_path_dir(dir_path)
+    except AttributeError:
+        pass  # Likely indicates a "partial refactor" BUG
+    finally:
+        arg_dict[ARG_DICT_KEY_DIR] = dir_path
     # word
     try:
-        words = _validate_path_arg(file_arg=parsed_args.words, arg_name='--words')
+        words = _validate_path_arg(path_arg=parsed_args.words, arg_name='--words')
+        validate_path_file(words)
     except AttributeError:
         pass  # Likely indicates a "partial refactor" BUG
     finally:
@@ -77,15 +102,15 @@ def parse_lima_args() -> Dict[str, Path]:
     return arg_dict
 
 
-def _validate_path_arg(file_arg: str, arg_name: str) -> Path:
+def _validate_path_arg(path_arg: str, arg_name: str) -> Path:
     """Validate file arguments and construct Path objects.
 
     Args:
-        file_arg: Absolute or relative filename.
+        path_arg: Absolute or relative filename.
         arg_name: Name of the argument to include in Exception messages.
 
     Returns:
-        Path object for file_arg.
+        Path object for path_arg.
 
     Raises:
         FileNotFoundError: arg_name value not found
@@ -93,8 +118,7 @@ def _validate_path_arg(file_arg: str, arg_name: str) -> Path:
         TypeError: Bad datatype
         ValueError: Blank(?) arg_name value
     """
-    validate_string(file_arg, 'file_arg')
+    validate_string(path_arg, 'path_arg')
     validate_string(arg_name, 'arg_name')
-    file_path = Path(file_arg)
-    validate_path_file(file_path)
+    file_path = Path(path_arg)
     return file_path

--- a/lima/lima_args.py
+++ b/lima/lima_args.py
@@ -61,13 +61,13 @@ def parse_lima_args() -> Dict[str, Path]:
     file_parser.add_argument('-f', '--file', action='store', required=True,
                              help='Target file to search for dirty words')
     file_parser.add_argument('-w', '--words', action='store', required=True,
-                        help='Dirty word list')
+                             help='Dirty word list')
     # Use Case 2: Directory
     dir_parser = subs.add_parser('dir', help='Search a directory for files with dirty words')
     dir_parser.add_argument('-d', '--dir', action='store', required=True,
                             help='Search for dirty words in all files found in this directory')
     dir_parser.add_argument('-w', '--words', action='store', required=True,
-                        help='Dirty word list')
+                            help='Dirty word list')
 
     # Parse
     parsed_args = parser.parse_args()

--- a/lima/lima_main.py
+++ b/lima/lima_main.py
@@ -12,8 +12,8 @@
 import sys
 # Third Party Imports
 # Local Imports
-from lima.lima_args import ARG_DICT_KEY_FILE, ARG_DICT_KEY_WORDS, parse_lima_args
-from lima.lima_search import get_dirty_words, search_file
+from lima.lima_args import ARG_DICT_KEY_DIR, ARG_DICT_KEY_FILE, ARG_DICT_KEY_WORDS, parse_lima_args
+from lima.lima_search import get_dirty_words, search_dir, search_file
 
 
 # pylint: disable=broad-except
@@ -38,6 +38,7 @@ def main() -> int:
     """
     # LOCAL VARIABLES
     exit_code = 0     # 0 on success, 1 for bad input, 2 on exception, 3 if dirty words found
+    temp_exit = 0     # Temporary exit code for successive function calls
     arg_dict = {}     # Dictionary of command line arguments
     dirty_words = []  # List of dirty words parsed from the command line
 
@@ -49,7 +50,16 @@ def main() -> int:
         exit_code = 1
     else:
         dirty_words = get_dirty_words(arg_dict[ARG_DICT_KEY_WORDS])
-        exit_code = search_file(arg_dict[ARG_DICT_KEY_FILE], dirty_words)
+        # Use Case 1
+        if arg_dict[ARG_DICT_KEY_FILE]:
+            temp_code = search_file(arg_dict[ARG_DICT_KEY_FILE], dirty_words)
+            if temp_code != 0:
+                exit_code = temp_code
+        # Use Case 2
+        if arg_dict[ARG_DICT_KEY_DIR]:
+            temp_code = search_dir(arg_dict[ARG_DICT_KEY_DIR], dirty_words)
+            if temp_code != 0:
+                exit_code = temp_code
 
     # DONE
     return exit_code

--- a/lima/lima_main.py
+++ b/lima/lima_main.py
@@ -38,7 +38,7 @@ def main() -> int:
     """
     # LOCAL VARIABLES
     exit_code = 0     # 0 on success, 1 for bad input, 2 on exception, 3 if dirty words found
-    temp_exit = 0     # Temporary exit code for successive function calls
+    temp_code = 0     # Temporary exit code for successive function calls
     arg_dict = {}     # Dictionary of command line arguments
     dirty_words = []  # List of dirty words parsed from the command line
 

--- a/lima/lima_search.py
+++ b/lima/lima_search.py
@@ -6,7 +6,8 @@ from typing import List
 import sys
 # Third Party Imports
 # Local Imports
-from lima.lima_validation import validate_path_file, validate_string, validate_type
+from lima.lima_validation import (validate_path_dir, validate_path_file,
+                                  validate_string, validate_type)
 
 
 def get_dirty_words(dw_path: Path) -> List[str]:
@@ -34,6 +35,45 @@ def get_dirty_words(dw_path: Path) -> List[str]:
 
     # DONE
     return dw_list
+
+
+def search_dir(dir_path: Path, dw_list: List[str], case_sensitive: bool = True) -> int:
+    """Searches dir_path for files that contain dw_list entries.
+
+    Prints findings to stderr.
+
+    Args:
+        dir_path: Path object to a directory to search.
+        dw_list: A list of non-empty strings to search file_path for.
+        case_sensitive: Optional; Considers case when checking file_path contents for dirty words.
+
+    Returns:
+        0 if no dirty words were found, 3 if dirty words were found.
+
+    Raises:
+        FileNotFoundError: dir_path is unavailable.
+        OSError: dir_path is not a directory.
+        TypeError: Bad data type.
+        ValueError: Bad value (e.g., empty string).
+    """
+    # LOCAL VARIABLES
+    target_files = []  # List of files found within dir_path to search for dirty words
+    temp_found = 0     # Temporary return value storage
+    found = 0          # 0 if no dirty words were found, 3 if dirty words were found
+
+    # INPUT VALIDATION
+    validate_path_dir(dir_path)
+
+    # SEARCH IT
+    target_files = [t_file for t_file in dir_path.iterdir() if t_file.is_file()]
+    for target_file in target_files:
+        temp_found = search_file(file_path=target_file, dw_list=dw_list,
+                                 case_sensitive=case_sensitive)
+        if temp_found != 0:
+            found = temp_found
+
+    # DONE
+    return found
 
 
 def search_file(file_path: Path, dw_list: List[str], case_sensitive: bool = True) -> int:

--- a/lima/lima_validation.py
+++ b/lima/lima_validation.py
@@ -7,6 +7,23 @@ from typing import Any
 # Local Imports
 
 
+def validate_path_dir(path_dir: Path) -> None:
+    """Validate a Path object as a directoryh.
+
+    Args:
+        path_dir: Path object to validate as a directory.
+
+    Raises:
+        TypeError: Bad data type.
+        FileNotFoundError: path_dir is unavailable.
+        OSError: path_dir is not a directory.
+    """
+    # INPUT VALIDATION
+    _validate_path_obj(path_dir, 'path_dir')
+    if not path_dir.is_dir():
+        raise OSError(f'{path_dir.absolute()} is not a directory')
+
+
 def validate_path_file(path_file: Path) -> None:
     """Validate a Path object as a file.
 
@@ -19,13 +36,7 @@ def validate_path_file(path_file: Path) -> None:
         OSError: path_file is not a file.
     """
     # INPUT VALIDATION
-    if path_file is None:
-        raise TypeError('Path has not been defined')
-    validate_type(path_file, 'path_file', Path)
-
-    # VALIDATE IT
-    if not path_file.exists():
-        raise FileNotFoundError(f'Unable to locate {path_file.absolute()}')
+    _validate_path_obj(path_file, 'path_file')
     if not path_file.is_file():
         raise OSError(f'{path_file.absolute()} is not a file')
 
@@ -68,3 +79,23 @@ def validate_type(var: Any, var_name: str, var_type: type) -> None:
     """
     if not isinstance(var, var_type):
         raise TypeError(f'{var_name} expected type {var_type}, instead received type {type(var)}')
+
+def _validate_path_obj(path_obj: Path, arg_name: str) -> None:
+    """Validate a Path object.
+
+    Args:
+        path_obj: Path object to validate.
+
+    Raises:
+        TypeError: Bad data type.
+        FileNotFoundError: path_obj is unavailable.
+    """
+    # INPUT VALIDATION
+    validate_string(arg_name, 'arg_name')
+    if path_obj is None:
+        raise TypeError(f'Path {arg_name} has not been defined')
+    validate_type(path_obj, arg_name, Path)
+
+    # VALIDATE IT
+    if not path_obj.exists():
+        raise FileNotFoundError(f'Unable to locate {path_obj.absolute()}')

--- a/lima/lima_validation.py
+++ b/lima/lima_validation.py
@@ -80,6 +80,7 @@ def validate_type(var: Any, var_name: str, var_type: type) -> None:
     if not isinstance(var, var_type):
         raise TypeError(f'{var_name} expected type {var_type}, instead received type {type(var)}')
 
+
 def _validate_path_obj(path_obj: Path, arg_name: str) -> None:
     """Validate a Path object.
 


### PR DESCRIPTION
Command line arguments now (essentially) include a Use Case 1 (file) and Use Case 2 (directory) usage.  It was implemented with a subparser so now LIMA has subcommands:

Use Case 1
`python -m lima file -f input.txt -w words4.txt`

Use Case 2
`python -m lima dir -d /tmp -w words4.txt`

This refactor will easily support LIMA-4's recursive option.