### PR TITLE
Lima 4

### DIFF
--- a/lima/lima_args.py
+++ b/lima/lima_args.py
@@ -11,9 +11,10 @@ from lima.lima_validation import validate_path_dir, validate_path_file, validate
 
 
 # ARGUMENT DICTIONARY KEYS
-ARG_DICT_KEY_FILE = 'file'    # -f, --file
-ARG_DICT_KEY_DIR = 'dir'      # -d, --dir
-ARG_DICT_KEY_WORDS = 'words'  # -w, --words
+ARG_DICT_KEY_FILE = 'file'      # -f, --file
+ARG_DICT_KEY_DIR = 'dir'        # -d, --dir
+ARG_DICT_KEY_WORDS = 'words'    # -w, --words
+ARG_DICT_KEY_RECUR = 'recurse'  # -r, --recursive
 
 
 class LimaParser(argparse.ArgumentParser):
@@ -68,6 +69,8 @@ def parse_lima_args() -> Dict[str, Path]:
                             help='Search for dirty words in all files found in this directory')
     dir_parser.add_argument('-w', '--words', action='store', required=True,
                             help='Dirty word list')
+    dir_parser.add_argument('-r', '--recursive', action='store_true', required=False,
+                            help='Dirty word list', default=False)
 
     # Parse
     parsed_args = parser.parse_args()
@@ -97,6 +100,11 @@ def parse_lima_args() -> Dict[str, Path]:
         pass  # Likely indicates a "partial refactor" BUG
     finally:
         arg_dict[ARG_DICT_KEY_WORDS] = words_path
+    # recursive
+    try:
+        arg_dict[ARG_DICT_KEY_RECUR] = parsed_args.recursive
+    except AttributeError:
+        arg_dict[ARG_DICT_KEY_RECUR] = False  # Likely indicates a "partial refactor" BUG
 
     # DONE
     return arg_dict

--- a/lima/lima_main.py
+++ b/lima/lima_main.py
@@ -12,7 +12,8 @@
 import sys
 # Third Party Imports
 # Local Imports
-from lima.lima_args import ARG_DICT_KEY_DIR, ARG_DICT_KEY_FILE, ARG_DICT_KEY_WORDS, parse_lima_args
+from lima.lima_args import (ARG_DICT_KEY_DIR, ARG_DICT_KEY_FILE, ARG_DICT_KEY_RECUR,
+                            ARG_DICT_KEY_WORDS, parse_lima_args)
 from lima.lima_search import get_dirty_words, search_dir, search_file
 
 
@@ -57,7 +58,8 @@ def main() -> int:
                 exit_code = temp_code
         # Use Case 2
         if arg_dict[ARG_DICT_KEY_DIR]:
-            temp_code = search_dir(arg_dict[ARG_DICT_KEY_DIR], dirty_words)
+            temp_code = search_dir(arg_dict[ARG_DICT_KEY_DIR], dirty_words,
+                                   recursive=arg_dict[ARG_DICT_KEY_RECUR])
             if temp_code != 0:
                 exit_code = temp_code
 


### PR DESCRIPTION
Added a `-r, --recursive` command line option to Use Case 2 (dir).  Now `lima dir` will recursively walk the directory you give it and search all the files it finds for dirty words.

Local testing appears to be working.  Example usage of the new feature:

`python -m lima dir -d ~ -w dirty_words.txt -r`